### PR TITLE
fix on uploading files with url encoded name (from some email clients…

### DIFF
--- a/Services/FileUploader.php
+++ b/Services/FileUploader.php
@@ -83,11 +83,32 @@ class FileUploader
         return sprintf(
             '%s-%s',
             uniqid(),
-            preg_replace(
-                '/\s+/',
-                '-',
-                $this->translator->transliterate($originalName)
-            )
+            $this->clearName($originalName)
+        );
+    }
+
+    /**
+     * Name cleanup
+     * @param $originalName
+     * @return string
+     */
+    protected function clearName($originalName)
+    {
+        //basic check on URL encoding
+        if (urldecode($originalName) !== $originalName) {
+            $originalName = urldecode($originalName);
+        }
+
+        $originalName = preg_replace(
+            '/[\+\\/\%]+/',
+            '_',
+            $originalName
+        );
+
+        return preg_replace(
+            '/\s+/',
+            '-',
+            $this->translator->transliterate($originalName)
         );
     }
 


### PR DESCRIPTION
Если называть файлы URL encoded именами, или содержащими некорректные символы, то ссылки на aws могут не работать. В коммите поправлены некоторые кейсы