### PR TITLE
escaping hash symbol for uploaded filenames

### DIFF
--- a/Services/FileUploader.php
+++ b/Services/FileUploader.php
@@ -100,7 +100,7 @@ class FileUploader
         }
 
         $originalName = preg_replace(
-            '/[\+\\/\%]+/',
+            '/[\+\\/\%\#\?]+/',
             '_',
             $originalName
         );


### PR DESCRIPTION
Если загрузить на Amazon файл с символом хэша (#) в названии, то ссылка для скачивания портится, файл становится невозможно загрузить. В коммите решетки экранируются.