### PR TITLE
Uploaded files should'n contain quotes (single and double) and slashes

### DIFF
--- a/Services/FileUploader.php
+++ b/Services/FileUploader.php
@@ -100,7 +100,7 @@ class FileUploader
         }
 
         $originalName = preg_replace(
-            '/[\+\\/\%\#\?]+/',
+            '/[\+\\/\\\\\%\#\?\"\'\`]+/',
             '_',
             $originalName
         );


### PR DESCRIPTION
В некоторых случаях файлы с кавычками некорректно обрабатываются в Amazon Bucket. Это касается в основном экранированных кавычек в названии файла (например, image\".jpg).